### PR TITLE
Returning general TCP info

### DIFF
--- a/bbrconn.go
+++ b/bbrconn.go
@@ -11,11 +11,19 @@ import (
 	"github.com/mikioh/tcp"
 )
 
-type InfoCallback func(bytesWritten int, info *tcpinfo.BBRInfo, err error)
+type InfoCallback func(bytesWritten int, info *tcpinfo.Info, bbrInfo *tcpinfo.BBRInfo, err error)
 
 type Conn interface {
 	net.Conn
-	Info() (bytesWritten int, info *tcpinfo.BBRInfo, err error)
+
+	// BytesWritten returns the number of bytes written to this connection
+	BytesWritten() int
+
+	// TCPInfo returns TCP connection info from the kernel
+	TCPInfo() (*tcpinfo.Info, error)
+
+	// BBRInfo returns BBR congestion avoidance info from the kernel
+	BBRInfo() (*tcpinfo.BBRInfo, error)
 }
 
 type bbrconn struct {

--- a/bbrconn_linux.go
+++ b/bbrconn_linux.go
@@ -44,7 +44,7 @@ func (conn *bbrconn) BytesWritten() int {
 
 func (conn *bbrconn) TCPInfo() (*tcpinfo.Info, error) {
 	var o tcpinfo.Info
-	b := make([]byte, 10000)
+	b := make([]byte, o.Size())
 	i, err := conn.tconn.Option(o.Level(), o.Name(), b)
 	if err != nil {
 		return nil, err
@@ -53,8 +53,9 @@ func (conn *bbrconn) TCPInfo() (*tcpinfo.Info, error) {
 }
 
 func (conn *bbrconn) BBRInfo() (*tcpinfo.BBRInfo, error) {
+	var bo tcpinfo.BBRInfo
 	var o tcpinfo.CCInfo
-	b := make([]byte, 100)
+	b := make([]byte, bo.Size())
 	i, err := conn.tconn.Option(o.Level(), o.Name(), b)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For getlantern/lantern-internal#743

Note, the API is changing, but right now the only consumer of this API is http-proxy-lantern, which is changing for this anyway.