### PR TITLE
Switched back to mikioh/tcpinfo now that it supports BBR

### DIFF
--- a/bbrconn.go
+++ b/bbrconn.go
@@ -7,8 +7,8 @@ import (
 	"net"
 	"sync/atomic"
 
-	"github.com/getlantern/tcpinfo"
 	"github.com/mikioh/tcp"
+	"github.com/mikioh/tcpinfo"
 )
 
 type InfoCallback func(bytesWritten int, info *tcpinfo.Info, bbrInfo *tcpinfo.BBRInfo, err error)

--- a/bbrconn_linux.go
+++ b/bbrconn_linux.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	sizeOfTCPInfo    = 0xc0
-	sizeOfTCPBBRInfo = 0x14
+	sizeOfTCPInfo    = 0xc0 // taken from github.com/mikioh/tcpinfo/syslinux.go
+	sizeOfTCPBBRInfo = 0x14 // taken from github.com/mikioh/tcpinfo/syslinux.go
 )
 
 func Wrap(conn net.Conn, onClose InfoCallback) (Conn, error) {

--- a/bbrconn_linux.go
+++ b/bbrconn_linux.go
@@ -9,8 +9,13 @@ import (
 	"sync/atomic"
 
 	"github.com/getlantern/netx"
-	"github.com/getlantern/tcpinfo"
 	"github.com/mikioh/tcp"
+	"github.com/mikioh/tcpinfo"
+)
+
+const (
+	sizeOfTCPInfo    = 0xc0
+	sizeOfTCPBBRInfo = 0x14
 )
 
 func Wrap(conn net.Conn, onClose InfoCallback) (Conn, error) {
@@ -44,7 +49,7 @@ func (conn *bbrconn) BytesWritten() int {
 
 func (conn *bbrconn) TCPInfo() (*tcpinfo.Info, error) {
 	var o tcpinfo.Info
-	b := make([]byte, o.Size())
+	b := make([]byte, sizeOfTCPInfo)
 	i, err := conn.tconn.Option(o.Level(), o.Name(), b)
 	if err != nil {
 		return nil, err
@@ -53,9 +58,8 @@ func (conn *bbrconn) TCPInfo() (*tcpinfo.Info, error) {
 }
 
 func (conn *bbrconn) BBRInfo() (*tcpinfo.BBRInfo, error) {
-	var bo tcpinfo.BBRInfo
 	var o tcpinfo.CCInfo
-	b := make([]byte, bo.Size())
+	b := make([]byte, sizeOfTCPBBRInfo)
 	i, err := conn.tconn.Option(o.Level(), o.Name(), b)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For getlantern/lantern-internal#2104.

The upstream tcpinfo now supports BBR, so I'm switching to that. This likely won't resolve the data race, but we might as well stay up-to-date with upstream.

I tested by building an http-proxy and pushing it to a live server and making sure that I still get an updated BBR estimate.